### PR TITLE
[Feature/#3] Jasypt 암호화 라이브러리 적용합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "jasypt.encryptor.password", System.getProperty("jasypt.encryptor.password")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,19 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// 개발 도구
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// 인증
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// 데이터베이스
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// 암호화 라이브러리
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sporthustle/hustle/config/JasyptConfig.java
+++ b/src/main/java/com/sporthustle/hustle/config/JasyptConfig.java
@@ -1,0 +1,30 @@
+package com.sporthustle.hustle.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String encryptKey;
+
+    @Bean(name = "jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(encryptKey);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
+++ b/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
@@ -1,0 +1,28 @@
+package com.sporthustle.hustle.jasypt;
+
+import com.sporthustle.hustle.config.JasyptConfig;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JasyptTest extends JasyptConfig {
+
+    @Test
+    public void 평문_암호화_결과_출력() {
+        String encryptKey = System.getProperty("jasypt.encryptor.password");
+
+        // 암호화할 평문 작성하기
+        String plainText = "";
+
+        StandardPBEStringEncryptor jasypt = new StandardPBEStringEncryptor();
+        jasypt.setPassword(encryptKey);
+
+        String encryptedText = jasypt.encrypt(plainText);
+        String decryptedText = jasypt.decrypt(encryptedText);
+
+        System.out.println(encryptedText);
+
+        assertThat(plainText).isEqualTo(decryptedText);
+    }
+}

--- a/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
+++ b/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
@@ -21,6 +21,7 @@ public class JasyptTest extends JasyptConfig {
         String encryptedText = jasypt.encrypt(plainText);
         String decryptedText = jasypt.decrypt(encryptedText);
 
+        // 테스트 결과에서 암호문 확인 가능
         System.out.println(encryptedText);
 
         assertThat(plainText).isEqualTo(decryptedText);


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- [Feature/#3](https://github.com/HUSTLE-UMC/HUSTLE_server/tree/Feature/%233)

### 💡 작업동기
- YML 설정 파일에서 민감한 정보를 암호화한 채로 레포에 올리기 위해 작업했습니다.

### 🔑 주요 변경사항
- `Jasypt` 라이브러리 의존성 추가
- 암호화하여 결과 출력해주는 테스트 코드 추가

### 🏞 스크린샷

테스트 코드 실행 시 아래에 평문을 암호화한 결과가 나옴.

```
...
> Task :test

cA9rf0NPm6Zk4njW4rjyOpa44CX/Xi7c

BUILD SUCCESSFUL in 15s
...
```

### 관련 이슈
- #3 

### 참고 사항
Jasypt 암호화 키는 백엔드 팀 노션 '계정 및 보안' 에 추가로 작성했습니다.
설정 방법은 `HustleApplication` 실행 시에 Run Configuration 을 추가합니다.
인텔리제이 IDE 에서 Add VM options... 을 한 뒤에
`-Djasypt.encryptor.password=시크릿키`
로 등록하면 됩니다. 테스트 코드 또한 위 설정을 적용합니다.
( 배포 때도 EC2 환경에서 Jar 파일 실행 시 위 시크릿키를 주입해야 합니다. )

참고 링크 : https://itchipmunk.tistory.com/541

Jasypt 라이브러리 적용 후에 YML 파일 작성시 아래처럼 ENC(암호화한값) 으로 작성하면 됩니다.

```yml
spring:
  datasource:
    url: ENC(qJcIphp38nLK6wAUrFUJv6MsP1XaMwEHY2nO22BQEPIEF8yWA1eQIUCsVxDIZ6XJm70jIm8XjBGlxKblYHGFx/MaGU7c0Zz2I4nnLYTe3YD8ne+n9g1VZwwhpdS666PEEkkhFraY9Ck84lIoFmTR=)
    username: ENC(CVvoCs9unAbL2iuSbkbF+mPj)
    password: ENC(45XI2J452h/sW7S58rL7q/N9bpb5oks=)
```
