### PR TITLE
[Fix/#14] jasypt 패스워드 은닉을 위해 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,4 +61,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "jasypt.encryptor.password", System.getProperty("jasypt.encryptor.password")
 }

--- a/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
+++ b/src/test/java/com/sporthustle/hustle/jasypt/JasyptTest.java
@@ -2,25 +2,28 @@ package com.sporthustle.hustle.jasypt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sporthustle.hustle.common.config.JasyptConfig;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-public class JasyptTest {
-
-  @Value("${jasypt.encryptor.password}")
-  private String encryptKey;
+public class JasyptTest extends JasyptConfig {
 
   @Test
-  void jasypt_테스트() {
-    String plainKey = "";
+  public void 평문_암호화_결과_출력() {
+    String encryptKey = System.getProperty("jasypt.encryptor.password");
+
+    // 암호화할 평문 작성하기
+    String plainText = "";
+
     StandardPBEStringEncryptor jasypt = new StandardPBEStringEncryptor();
     jasypt.setPassword(encryptKey);
-    String encryptedText = jasypt.encrypt(plainKey);
+
+    String encryptedText = jasypt.encrypt(plainText);
     String decryptedText = jasypt.decrypt(encryptedText);
 
-    assertThat(plainKey).isEqualTo(decryptedText);
+    // 테스트 결과에서 암호문 확인 가능
+    System.out.println(encryptedText);
+
+    assertThat(plainText).isEqualTo(decryptedText);
   }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- #14 

### 💡 작업동기
- jasypt의 암호 비밀번호가 노출된 상태이므로 설정 수정

### 🔑 주요 변경사항
- jasypt 테스트 로직 수정
- build.gradle 수정

### 🏞 스크린샷
- build.gradle
<img width="697" alt="스크린샷 2023-07-23 오전 12 59 52" src="https://github.com/HUSTLE-UMC/HUSTLE_server/assets/76439068/12690176-f81d-490a-8143-1eaa81762395">

- 테스트 코드 (다람님 코드 복붙)
<img width="612" alt="스크린샷 2023-07-23 오전 1 00 05" src="https://github.com/HUSTLE-UMC/HUSTLE_server/assets/76439068/8465a303-a288-4f89-aae3-82115f59575f">


### 관련 이슈
- 관련 이슈를 입력해주세요.
