### PR TITLE
[Feat/#30] MySQL8 도커 컨테이너 추가와 application.yml 환경 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-*.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  mysql:
+    image: mysql:8.0
+    platform: linux/amd64
+    ports:
+      - "3306:3306"
+    volumes:
+      - hustle-mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: hustle
+
+volumes:
+  hustle-mysql-data:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,34 +1,55 @@
+### jpa setting ###
 spring:
-  datasource:
-    driver-class-name: ENC(4zv7k66bl0S9CkPIg0RRzaWiUGE2DhjRaIxsA8E9l+kWvMMPExbdHg==)
-    url: ENC(n4BgVC45DNHZ7Dv+eIGHp6NmDrt9UVXY93jMqfOq+Eb4lRi9oP6by9eJ3NuZGKrnk1QUdrQ4J2QFWMTvqV9AuCG2y500vtLwPJngcLnbAz1JxooZAJoNCxYOyW1HwFnOY0zEqGA45hhAZxCpZEKn4IPiX8JOxYZpl13BDw/qoExcYplGW3GJVD3mhD1Yqy2B)
-    username: ENC(3IlDHh9Hevic4hySvkJUVfhwVklsc20q)
-    password: ENC(Z9yNmaE1Sk5DKZerehtnl+GNz3MfhVBsrT8obGfbaLU=)
-
-  ### jpa setting ###
   jpa:
     hibernate:
       ddl-auto: create-drop
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         format_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
 
-  ### spring security ###
-  security:
-    user:
-      name: ENC(oVSEw6gxE46j0SJPrnVgyg==)
-      password: ENC(kyHrVONdlwShgsY4YOKmiZDmH3g3tCae4Z55N6qyyYypqG0AQWsF6g==)
-    #      roles: USER, ADMIN
+### spring security ###
+security:
+  user:
+    name: ENC(oVSEw6gxE46j0SJPrnVgyg==)
+    password: ENC(kyHrVONdlwShgsY4YOKmiZDmH3g3tCae4Z55N6qyyYypqG0AQWsF6g==)
+  #      roles: USER, ADMIN
 
+### jwt ###
 jwt:
   secret:
     key: ENC(8Zdp8FGcysujUJk7CiGhHKrm3IzIWAa7Id0Wa2sdBptB1me6LzYxptMoABBZPqvh81xeo+E7nrsK/bzOwf5r1g==)
 
-  ### Swagger ###
+### Swagger ###
 springdoc:
   swagger-ui:
     enabled: true
     try-it-out-enabled: true
   version: 'v1'
+
+---
+spring.config:
+  activate:
+    on-profile: local
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/hustle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
+
+---
+spring.config:
+  activate:
+    on-profile: prod
+
+spring:
+  datasource:
+    driver-class-name: ENC(4zv7k66bl0S9CkPIg0RRzaWiUGE2DhjRaIxsA8E9l+kWvMMPExbdHg==)
+    url: ENC(n4BgVC45DNHZ7Dv+eIGHp6NmDrt9UVXY93jMqfOq+Eb4lRi9oP6by9eJ3NuZGKrnk1QUdrQ4J2QFWMTvqV9AuCG2y500vtLwPJngcLnbAz1JxooZAJoNCxYOyW1HwFnOY0zEqGA45hhAZxCpZEKn4IPiX8JOxYZpl13BDw/qoExcYplGW3GJVD3mhD1Yqy2B)
+    username: ENC(3IlDHh9Hevic4hySvkJUVfhwVklsc20q)
+    password: ENC(Z9yNmaE1Sk5DKZerehtnl+GNz3MfhVBsrT8obGfbaLU=)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
         format_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/hustle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
 
 ### spring security ###
 security:
@@ -29,18 +34,6 @@ springdoc:
     enabled: true
     try-it-out-enabled: true
   version: 'v1'
-
----
-spring.config:
-  activate:
-    on-profile: local
-
-spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/hustle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    password: root
 
 ---
 spring.config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,9 @@ spring.config:
     on-profile: prod
 
 spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
   datasource:
     driver-class-name: ENC(4zv7k66bl0S9CkPIg0RRzaWiUGE2DhjRaIxsA8E9l+kWvMMPExbdHg==)
     url: ENC(n4BgVC45DNHZ7Dv+eIGHp6NmDrt9UVXY93jMqfOq+Eb4lRi9oP6by9eJ3NuZGKrnk1QUdrQ4J2QFWMTvqV9AuCG2y500vtLwPJngcLnbAz1JxooZAJoNCxYOyW1HwFnOY0zEqGA45hhAZxCpZEKn4IPiX8JOxYZpl13BDw/qoExcYplGW3GJVD3mhD1Yqy2B)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Feature/#30`

### 💡 작업동기
- MySQL8 을 연동 시 실제 DB 와 연동하는 걸 막기 위해 실서버는 `application.yml` 에서 `prod` 프로필로 분리했습니다.

### 🔑 주요 변경사항
- `.gitignore` 에서 `yml` 제외 설정 삭제
- `application.yml` `prod` 프로필 환경 분리

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #30 

### 참고사항
- `.gitignore` 에서 `application.yml` 제외 설정 삭제했습니다.
- 기본 프로필은 로컬 도커 MySQL 컨테이너를 실행하도록 수정했습니다.
- 실서버 실행 시 `-Djasypt.encryptor.password={...} -Dspring.profiles.active=default,prod` 으로 Jar 실행해야합니다.
- 실서버는 `ddl-auto: none` 으로 테이블이 자동으로 변경되지 않습니다.
- MySQL 도커 컨테이너는 루트 프로젝트에서 `docker-compose up -d` 으로 런칭이 가능합니다.
