### PR TITLE
[Fix/#48] 비밀번호 재설정을 위한 계정 조회 쿼리 메서드 수정

### DIFF
--- a/src/main/java/com/sporthustle/hustle/src/user/UserRepository.java
+++ b/src/main/java/com/sporthustle/hustle/src/user/UserRepository.java
@@ -13,4 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByEmailAndState(String email, BaseState state);
 
   Optional<User> findByNameAndBirthAndState(String name, Date birth, BaseState state);
+
+  boolean existsByNameAndBirthAndEmailAndState(
+      String name, Date birth, String email, BaseState state);
 }

--- a/src/main/java/com/sporthustle/hustle/src/user/UserService.java
+++ b/src/main/java/com/sporthustle/hustle/src/user/UserService.java
@@ -83,7 +83,8 @@ public class UserService {
   }
 
   public boolean findAccount(FindAccountReq findAccountReq) {
-    return userRepository.existsByEmailAndState(findAccountReq.getEmail(), ACTIVE);
+    return userRepository.existsByNameAndBirthAndEmailAndState(
+        findAccountReq.getName(), findAccountReq.getBirth(), findAccountReq.getEmail(), ACTIVE);
   }
 
   public void modifyUserInfo(ModifyUserInfoReq modifyUserInfoReq) {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/#48

### 💡 작업동기
- 이메일으로만 계정 조회를 했을 때 존재하지 않는 계정의 이름과 생년월일을 입력하면 정상적으로 조회되는 문제 발생
- 비밀번호 재설정을 위한 계정 조회 쿼리 메서드 수정

### 🔑 주요 변경사항
- 비밀번호 재설정을 위한 계정 조회 쿼리 메서드 수정

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- close #48 
