### PR TITLE
[Bug] 스웨거에 `https` 프로토콜을 대응하기 위한 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,14 @@ spotless {
 }
 
 group = 'com.sport-hustle'
-version = '0.0.2-SNAPSHOT'
+version = 'v0.0.2'
 
 java {
 	sourceCompatibility = '11'
+}
+
+springBoot {
+	buildInfo()
 }
 
 configurations {

--- a/src/main/java/com/sporthustle/hustle/common/config/SwaggerConfig.java
+++ b/src/main/java/com/sporthustle/hustle/common/config/SwaggerConfig.java
@@ -40,5 +40,21 @@ public class SwaggerConfig {
                     .in(SecurityScheme.In.HEADER)
                     .name("Authorization"));
     return new OpenAPI().info(info).addSecurityItem(securityRequirement).components(components);
+
+  private List<Server> getServers() {
+    /*
+    url 을 지정해주지 않으면 실서버에서 스웨거 테스트 시 http 프로토콜로 실행되어 오류 발생으로 테스트가 불가능해짐
+    */
+    Server productionServer =
+        new Server().url("https://api.sport-hustle.com").description("Production Server");
+
+    Server localServer = new Server().url("/").description("Local/Current Server");
+
+    List<Server> servers = new ArrayList<>();
+    servers.add(productionServer);
+    servers.add(localServer);
+
+    return servers;
+  }
   }
 }

--- a/src/main/java/com/sporthustle/hustle/common/config/SwaggerConfig.java
+++ b/src/main/java/com/sporthustle/hustle/common/config/SwaggerConfig.java
@@ -5,13 +5,20 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.GroupedOpenApi;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
 
+  private final BuildProperties buildProperties;
+
+  private final String JWT_HEADER_NAME = "Authorization";
+  private final String JWT_SCHEME = "bearer";
   @Bean
   public GroupedOpenApi publicApi() {
     return GroupedOpenApi.builder().group("v1-definition").pathsToMatch("/api/**").build();


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Bug/#53`

### 💡 작업동기
- 스웨거에서 `https` 프로토콜이 적용되지 않아 API 테스트가 실패하는 오류가 발생해서 긴급 수정 필요

### 🔑 주요 변경사항
- 서버의 URL 을 담은 `ServerItem` 추가
- `OpenAPI` 객체 생성 시에 필요한, 객체들 생성하는 로직 메소드로 분리하여 리팩터링

### 🏞 스크린샷
![스크린샷 2023-08-15 오전 4 00 18](https://github.com/HUSTLE-UMC/HUSTLE_server/assets/16275188/06503110-3722-4466-b82b-5e3d024ac620)

### 관련 이슈
- close #53 
