### PR TITLE
[Feature] HOT 대회 목록 조회 API 작성

### DIFF
--- a/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
+++ b/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
@@ -95,9 +95,9 @@ public class CompetitionController {
   })
   @GetMapping("/popular")
   public ResponseEntity<Object> getPopularCompetitions(
-          @PageableDefault(size = 5, direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 5, direction = Sort.Direction.DESC) Pageable pageable) {
     CompetitionsResponseDTO competitionsResponseDTO =
-            competitionService.getPopularCompetitions(pageable);
+        competitionService.getPopularCompetitions(pageable);
     return ResponseEntity.ok(competitionsResponseDTO);
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
+++ b/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
@@ -32,7 +32,7 @@ public class CompetitionController {
       @RequestParam(name = "sport_event_id", required = false) Long sportEventId,
       @RequestParam(name = "state", defaultValue = "ACTIVE")
           CompetitionStateRequest competitionStateRequest,
-      @PageableDefault(size = 4, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 4, direction = Sort.Direction.DESC) Pageable pageable) {
     CompetitionsResponseDTO competitionsResponseDTO =
         competitionService.getCompetitionsByListType(
             sportEventId, competitionStateRequest, pageable);

--- a/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
+++ b/src/main/java/com/sporthustle/hustle/competition/CompetitionController.java
@@ -94,7 +94,10 @@ public class CompetitionController {
     @ApiResponse(responseCode = "200", description = "HOT 대회 목록 조회에 성공한 경우"),
   })
   @GetMapping("/popular")
-  public ResponseEntity<Object> getPopularCompetitions() {
-    return ResponseEntity.ok(null);
+  public ResponseEntity<Object> getPopularCompetitions(
+          @PageableDefault(size = 5, direction = Sort.Direction.DESC) Pageable pageable) {
+    CompetitionsResponseDTO competitionsResponseDTO =
+            competitionService.getPopularCompetitions(pageable);
+    return ResponseEntity.ok(competitionsResponseDTO);
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competition/CompetitionService.java
+++ b/src/main/java/com/sporthustle/hustle/competition/CompetitionService.java
@@ -212,4 +212,19 @@ public class CompetitionService {
 
     return DeleteCompetitionResponseDTO.builder().message("대회를 성공적으로 삭제했습니다.").build();
   }
+
+  @Transactional(readOnly = true)
+  public CompetitionsResponseDTO getPopularCompetitions(Pageable pageable) {
+    Page<Competition> competitions = competitionRepositoryCustom.getPopularCompetitions(pageable);
+
+    Page<CompetitionResponseDTO> competitionResponseDTOs =
+            competitions.map(competition -> CompetitionResponseDTO.from(competition));
+
+    return CompetitionsResponseDTO.builder()
+            .count(competitionResponseDTOs.getNumberOfElements())
+            .totalPage(competitionResponseDTOs.getTotalPages())
+            .totalCount(competitionResponseDTOs.getTotalElements())
+            .data(competitionResponseDTOs.getContent())
+            .build();
+  }
 }

--- a/src/main/java/com/sporthustle/hustle/competition/CompetitionService.java
+++ b/src/main/java/com/sporthustle/hustle/competition/CompetitionService.java
@@ -218,13 +218,13 @@ public class CompetitionService {
     Page<Competition> competitions = competitionRepositoryCustom.getPopularCompetitions(pageable);
 
     Page<CompetitionResponseDTO> competitionResponseDTOs =
-            competitions.map(competition -> CompetitionResponseDTO.from(competition));
+        competitions.map(competition -> CompetitionResponseDTO.from(competition));
 
     return CompetitionsResponseDTO.builder()
-            .count(competitionResponseDTOs.getNumberOfElements())
-            .totalPage(competitionResponseDTOs.getTotalPages())
-            .totalCount(competitionResponseDTOs.getTotalElements())
-            .data(competitionResponseDTOs.getContent())
-            .build();
+        .count(competitionResponseDTOs.getNumberOfElements())
+        .totalPage(competitionResponseDTOs.getTotalPages())
+        .totalCount(competitionResponseDTOs.getTotalElements())
+        .data(competitionResponseDTOs.getContent())
+        .build();
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competition/dto/CompetitionResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competition/dto/CompetitionResponseDTO.java
@@ -37,6 +37,8 @@ public class CompetitionResponseDTO {
 
   private Integer maxEntryCount;
 
+  private Integer entryCount;
+
   private String sponsor;
 
   private String posterUrl;
@@ -84,6 +86,7 @@ public class CompetitionResponseDTO {
         .recruitmentEndDate(competition.getRecruitmentEndDate())
         .entryFee(competition.getEntryFee())
         .maxEntryCount(competition.getMaxEntryCount())
+        .entryCount(competition.getEntryCount())
         .sponsor(competition.getSponsor())
         .posterUrl(competition.getPosterUrl())
         .preRoundGroupCount(competition.getPreRoundGroupCount())

--- a/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
+++ b/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
@@ -75,4 +75,26 @@ public class CompetitionRepositoryCustom {
     LocalDateTime now = LocalDateTime.now();
     return competition.endDate.goe(now);
   }
+
+  public Page<Competition> getPopularCompetitions(Pageable pageable) {
+    JPAQuery<Competition> countQuery =
+            queryFactory
+                    .selectFrom(competition)
+                    .leftJoin(competition.sportEvent, sportEvent)
+                    .leftJoin(competition.user, user)
+                    .where(inRecruiting())
+                    .orderBy(competition.entryCount.desc())
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize());
+
+    List<Competition> content = countQuery.fetch();
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+  }
+
+  private BooleanExpression inRecruiting() {
+    LocalDateTime now = LocalDateTime.now();
+
+    return competition.recruitmentStartDate.loe(now).and(competition.recruitmentEndDate.goe(now));
+  }
 }

--- a/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
+++ b/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
@@ -78,14 +78,14 @@ public class CompetitionRepositoryCustom {
 
   public Page<Competition> getPopularCompetitions(Pageable pageable) {
     JPAQuery<Competition> countQuery =
-            queryFactory
-                    .selectFrom(competition)
-                    .leftJoin(competition.sportEvent, sportEvent)
-                    .leftJoin(competition.user, user)
-                    .where(inRecruiting())
-                    .orderBy(competition.entryCount.desc())
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize());
+        queryFactory
+            .selectFrom(competition)
+            .leftJoin(competition.sportEvent, sportEvent)
+            .leftJoin(competition.user, user)
+            .where(inRecruiting())
+            .orderBy(competition.entryCount.desc(), competition.recruitmentEndDate.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
 
     List<Competition> content = countQuery.fetch();
 

--- a/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
+++ b/src/main/java/com/sporthustle/hustle/competition/repository/CompetitionRepositoryCustom.java
@@ -82,7 +82,7 @@ public class CompetitionRepositoryCustom {
             .selectFrom(competition)
             .leftJoin(competition.sportEvent, sportEvent)
             .leftJoin(competition.user, user)
-            .where(inRecruiting())
+            .where(nowBetweenRecruitingDate(), notMaxEntryCount())
             .orderBy(competition.entryCount.desc(), competition.recruitmentEndDate.asc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize());
@@ -92,9 +92,12 @@ public class CompetitionRepositoryCustom {
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
   }
 
-  private BooleanExpression inRecruiting() {
+  private BooleanExpression nowBetweenRecruitingDate() {
     LocalDateTime now = LocalDateTime.now();
-
     return competition.recruitmentStartDate.loe(now).and(competition.recruitmentEndDate.goe(now));
+  }
+
+  private BooleanExpression notMaxEntryCount() {
+    return competition.entryCount.lt(competition.maxEntryCount);
   }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Feature/#9`

### 💡 작업동기
- 모집 중인 대회 중에서 참가 인원이 제일 많은 순대로 HOT 대회 목록을 보여줍니다.
- 참가 인원이 많아 곧 모집이 마감 될 대회를 HOME 화면에 노출시켜, 대회 지원 마감율과 회전률을 높일 것으로 예상합니다.

### 🔑 주요 변경사항
- `getPopularCompetitions` QueryDSL 메소드로 작성
- 관련 컨트롤러 코드와 서비스 코드 작성
- 대회 엔티티 DTO 에 `entryCount` 필드 추가

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #9 
