### PR TITLE
[Feature] 대회 세부 정보 도메인 작성

### DIFF
--- a/src/main/java/com/sporthustle/hustle/common/config/WebConfig.java
+++ b/src/main/java/com/sporthustle/hustle/common/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.sporthustle.hustle.common.config;
 
 import com.sporthustle.hustle.common.converter.CompetitionTypeRequestConverter;
+import com.sporthustle.hustle.common.converter.InGameTypeRequestConverter;
 import com.sporthustle.hustle.common.resolver.AuthUserResolver;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new CompetitionTypeRequestConverter());
+    registry.addConverter(new InGameTypeRequestConverter());
   }
 
   @Override

--- a/src/main/java/com/sporthustle/hustle/common/converter/CompetitionTypeRequestConverter.java
+++ b/src/main/java/com/sporthustle/hustle/common/converter/CompetitionTypeRequestConverter.java
@@ -6,6 +6,6 @@ import org.springframework.core.convert.converter.Converter;
 public class CompetitionTypeRequestConverter implements Converter<String, CompetitionStateRequest> {
   @Override
   public CompetitionStateRequest convert(String competitionState) {
-    return CompetitionStateRequest.of(competitionState);
+    return CompetitionStateRequest.of(competitionState.toUpperCase());
   }
 }

--- a/src/main/java/com/sporthustle/hustle/common/converter/InGameTypeRequestConverter.java
+++ b/src/main/java/com/sporthustle/hustle/common/converter/InGameTypeRequestConverter.java
@@ -1,0 +1,11 @@
+package com.sporthustle.hustle.common.converter;
+
+import com.sporthustle.hustle.competitions.ingame.dto.InGameType;
+import org.springframework.core.convert.converter.Converter;
+
+public class InGameTypeRequestConverter implements Converter<String, InGameType> {
+  @Override
+  public InGameType convert(String inGameType) {
+    return InGameType.of(inGameType.toUpperCase());
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
+++ b/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
   COMPETITION_NOT_FOUND(BAD_REQUEST, "COMPETITION_NOT_FOUND", "해당 대회를 찾을 수 없습니다."),
   USER_NOT_OWNER(FORBIDDEN, "USER_NOT_OWNER", "접근 권한이 없습니다."),
   ENTRY_TEAM_NOT_FOUND(BAD_REQUEST, "ENTRY_TEAM_NOT_FOUND", "대회 참가팀이 아닙니다."),
+  PRE_ROUND_DETAIL_NOT_FOUND(BAD_REQUEST, "PRE_ROUND_DETAIL_NOT_FOUND", "예선 세부 정보를 찾을 수 없습니다."),
+  FINAL_ROUND_DETAIL_NOT_FOUND(BAD_REQUEST, "FINAL_ROUND_DETAIL_NOT_FOUND", "본선 세부 정보를 찾을 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionController.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionController.java
@@ -31,7 +31,7 @@ public class CompetitionController {
   public ResponseEntity<CompetitionsResponseDTO> getCompetitionsByYearAndMonthAndState(
       @RequestParam(name = "sport_event_id", required = false) Long sportEventId,
       @RequestParam(name = "state", defaultValue = "ACTIVE")
-      CompetitionStateRequest competitionStateRequest,
+          CompetitionStateRequest competitionStateRequest,
       @PageableDefault(size = 4, direction = Sort.Direction.DESC) Pageable pageable) {
     CompetitionsResponseDTO competitionsResponseDTO =
         competitionService.getCompetitionsByListType(

--- a/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionService.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionService.java
@@ -9,6 +9,7 @@ import com.sporthustle.hustle.competitions.competition.repository.CompetitionRep
 import com.sporthustle.hustle.competitions.competition.repository.CompetitionRepositoryCustom;
 import com.sporthustle.hustle.competitions.competition.repository.condition.CompetitionsBeforeCompleteCondition;
 import com.sporthustle.hustle.competitions.competition.repository.condition.RecentCompleteCompetitionsCondition;
+import com.sporthustle.hustle.competitions.ingame.CompetitionDetailService;
 import com.sporthustle.hustle.sport.SportUtils;
 import com.sporthustle.hustle.sport.entity.SportEvent;
 import com.sporthustle.hustle.sport.repository.SportEventRepository;
@@ -32,6 +33,7 @@ public class CompetitionService {
   private final CompetitionRepositoryCustom competitionRepositoryCustom;
   private final SportEventRepository sportEventRepository;
   private final UserRepository userRepository;
+  private final CompetitionDetailService competitionDetailService;
 
   @Transactional(readOnly = true)
   public CompetitionsResponseDTO getCompetitionsByListType(
@@ -131,6 +133,8 @@ public class CompetitionService {
 
     competitionRepository.save(competition);
 
+    competitionDetailService.createDetails(competition.getId());
+
     CompetitionResponseDTO competitionResponseDTO = CompetitionResponseDTO.from(competition);
 
     return CreateCompetitionResponseDTO.builder()
@@ -209,6 +213,8 @@ public class CompetitionService {
 
     competition.delete();
     competitionRepository.save(competition);
+
+    competitionDetailService.deleteDetails(competitionId);
 
     return DeleteCompetitionResponseDTO.builder().message("대회를 성공적으로 삭제했습니다.").build();
   }

--- a/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionService.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/competition/CompetitionService.java
@@ -37,7 +37,7 @@ public class CompetitionService {
 
   @Transactional(readOnly = true)
   public CompetitionsResponseDTO getCompetitionsByListType(
-          Long sportEventId, CompetitionStateRequest competitionStateRequest, Pageable pageable) {
+      Long sportEventId, CompetitionStateRequest competitionStateRequest, Pageable pageable) {
     Page<Competition> competitions = Page.empty();
 
     switch (competitionStateRequest) {

--- a/src/main/java/com/sporthustle/hustle/competitions/competition/repository/CompetitionRepositoryCustom.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/competition/repository/CompetitionRepositoryCustom.java
@@ -1,16 +1,15 @@
 package com.sporthustle.hustle.competitions.competition.repository;
 
-import static com.sporthustle.hustle.competitions.entity.competition.QCompetition.competition;
+import static com.sporthustle.hustle.competitions.competition.entity.QCompetition.competition;
 import static com.sporthustle.hustle.sport.entity.QSportEvent.sportEvent;
 import static com.sporthustle.hustle.user.entity.QUser.user;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.sporthustle.hustle.competitions.competition.repository.condition.RecentCompleteCompetitionsCondition;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
 import com.sporthustle.hustle.competitions.competition.repository.condition.CompetitionsBeforeCompleteCondition;
-
+import com.sporthustle.hustle.competitions.competition.repository.condition.RecentCompleteCompetitionsCondition;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +41,7 @@ public class CompetitionRepositoryCustom {
   }
 
   public Page<Competition> getRecentCompleteCompetitions(
-          RecentCompleteCompetitionsCondition condition, Pageable pageable) {
+      RecentCompleteCompetitionsCondition condition, Pageable pageable) {
 
     JPAQuery<Competition> countQuery =
         queryFactory

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/EntryTeamController.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/EntryTeamController.java
@@ -40,10 +40,11 @@ public class EntryTeamController {
   })
   @PostMapping("/{competition_id}/entry_team")
   public ResponseEntity<CreateEntryTeamResponseDTO> createEntryTeam(
-          @UserId Long userId,
-          @PathVariable("competition_id") Long competitionId,
-          @RequestBody CreateEntryTeamRequestDTO createEntryTeamRequestDTO) {
-    CreateEntryTeamResponseDTO createEntryTeamResponseDTO = entryTeamService.createEntryTeam(userId, competitionId, createEntryTeamRequestDTO);
+      @UserId Long userId,
+      @PathVariable("competition_id") Long competitionId,
+      @RequestBody CreateEntryTeamRequestDTO createEntryTeamRequestDTO) {
+    CreateEntryTeamResponseDTO createEntryTeamResponseDTO =
+        entryTeamService.createEntryTeam(userId, competitionId, createEntryTeamRequestDTO);
     return ResponseEntity.ok(createEntryTeamResponseDTO);
   }
 
@@ -53,9 +54,9 @@ public class EntryTeamController {
   })
   @DeleteMapping("/{competition_id}/entry_team")
   public ResponseEntity<DeleteEntryTeamResponseDTO> deleteEntryTeam(
-      @UserId Long userId,
-      @PathVariable("competition_id") Long competitionId) {
-    DeleteEntryTeamResponseDTO deleteEntryTeamResponseDTO = entryTeamService.deleteEntryTeam(userId, competitionId);
+      @UserId Long userId, @PathVariable("competition_id") Long competitionId) {
+    DeleteEntryTeamResponseDTO deleteEntryTeamResponseDTO =
+        entryTeamService.deleteEntryTeam(userId, competitionId);
     return ResponseEntity.ok(deleteEntryTeamResponseDTO);
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/EntryTeamService.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/EntryTeamService.java
@@ -8,19 +8,18 @@ import com.sporthustle.hustle.common.exception.ErrorCode;
 import com.sporthustle.hustle.competitions.competition.CompetitionUtils;
 import com.sporthustle.hustle.competitions.competition.dto.CompetitionState;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
+import com.sporthustle.hustle.competitions.competition.repository.CompetitionRepository;
 import com.sporthustle.hustle.competitions.entryteam.dto.*;
 import com.sporthustle.hustle.competitions.entryteam.entity.EntryTeam;
-import com.sporthustle.hustle.competitions.competition.repository.CompetitionRepository;
 import com.sporthustle.hustle.competitions.entryteam.repository.EntryTeamRepository;
 import com.sporthustle.hustle.user.UserUtils;
 import com.sporthustle.hustle.user.entity.User;
 import com.sporthustle.hustle.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -29,13 +28,14 @@ public class EntryTeamService {
   private final EntryTeamRepository entryTeamRepository;
   private final UserRepository userRepository;
   private final CompetitionRepository competitionRepository;
-  private  final ClubRepository clubRepository;
+  private final ClubRepository clubRepository;
 
   @Transactional(readOnly = true)
   public EntryTeamsResponseDTO getEntryTeams(Long competitionId) {
     List<EntryTeam> entryTeams = entryTeamRepository.findAllByCompetition_Id(competitionId);
 
-    List<EntryTeamResponseDTO> entryTeamDTOs = entryTeams.stream()
+    List<EntryTeamResponseDTO> entryTeamDTOs =
+        entryTeams.stream()
             .map(entryTeam -> EntryTeamResponseDTO.from(entryTeam))
             .collect(Collectors.toList());
 
@@ -43,12 +43,15 @@ public class EntryTeamService {
   }
 
   @Transactional
-  public CreateEntryTeamResponseDTO createEntryTeam(Long userId, Long competitionId, CreateEntryTeamRequestDTO createEntryTeamRequestDTO) {
+  public CreateEntryTeamResponseDTO createEntryTeam(
+      Long userId, Long competitionId, CreateEntryTeamRequestDTO createEntryTeamRequestDTO) {
     User user = UserUtils.getUserById(userId, userRepository);
-    Competition competition = CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
+    Competition competition =
+        CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
     Club club = ClubUtils.getClubById(createEntryTeamRequestDTO.getClubId(), clubRepository);
 
-    EntryTeam entryTeam = EntryTeam.builder()
+    EntryTeam entryTeam =
+        EntryTeam.builder()
             .name(createEntryTeamRequestDTO.getName())
             .phoneNumber(createEntryTeamRequestDTO.getPhoneNumber())
             .build();
@@ -62,18 +65,21 @@ public class EntryTeamService {
     EntryTeamResponseDTO entryTeamResponseDTO = EntryTeamResponseDTO.from(entryTeam);
 
     return CreateEntryTeamResponseDTO.builder()
-            .message("대회 참가에 성공하였습니다.")
-            .data(entryTeamResponseDTO)
-            .build();
+        .message("대회 참가에 성공하였습니다.")
+        .data(entryTeamResponseDTO)
+        .build();
   }
 
   @Transactional
   public DeleteEntryTeamResponseDTO deleteEntryTeam(Long userId, Long competitionId) {
-    Competition competition = CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
+    Competition competition =
+        CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
 
     validateCompetitionInRecruiting(competition);
 
-    EntryTeam entryTeam = entryTeamRepository.findByUser_IdAndCompetition_id(userId, competitionId)
+    EntryTeam entryTeam =
+        entryTeamRepository
+            .findByUser_IdAndCompetition_id(userId, competitionId)
             .orElseThrow(() -> BaseException.from(ErrorCode.ENTRY_TEAM_NOT_FOUND));
 
     entryTeamRepository.delete(entryTeam);
@@ -81,9 +87,9 @@ public class EntryTeamService {
     EntryTeamResponseDTO entryTeamResponseDTO = EntryTeamResponseDTO.from(entryTeam);
 
     return DeleteEntryTeamResponseDTO.builder()
-            .message("대회 참가를 취소했습니다.")
-            .data(entryTeamResponseDTO)
-            .build();
+        .message("대회 참가를 취소했습니다.")
+        .data(entryTeamResponseDTO)
+        .build();
   }
 
   private void validateCompetitionInRecruiting(Competition competition) {
@@ -91,12 +97,12 @@ public class EntryTeamService {
       throw new IllegalArgumentException("대회 값이 null 입니다.");
     }
 
-    CompetitionState competitionState = CompetitionState.from(
+    CompetitionState competitionState =
+        CompetitionState.from(
             competition.getRecruitmentStartDate(),
             competition.getRecruitmentEndDate(),
             competition.getStartDate(),
-            competition.getEndDate()
-    );
+            competition.getEndDate());
 
     if (competitionState != CompetitionState.RECRUITING) {
       throw new IllegalArgumentException("대회 참가를 변경할 수 있는 기간이 아닙니다.");

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/CreateEntryTeamRequestDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/CreateEntryTeamRequestDTO.java
@@ -1,9 +1,8 @@
 package com.sporthustle.hustle.competitions.entryteam.dto;
 
-import lombok.Getter;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import lombok.Getter;
 
 @Getter
 public class CreateEntryTeamRequestDTO {
@@ -16,5 +15,4 @@ public class CreateEntryTeamRequestDTO {
 
   @NotNull(message = "동아리는 필수 입력 값입니다.")
   private Long clubId;
-
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/CreateEntryTeamResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/CreateEntryTeamResponseDTO.java
@@ -10,5 +10,4 @@ public class CreateEntryTeamResponseDTO {
   private String message;
 
   private EntryTeamResponseDTO data;
-
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/DeleteEntryTeamResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/DeleteEntryTeamResponseDTO.java
@@ -10,5 +10,4 @@ public class DeleteEntryTeamResponseDTO {
   private String message;
 
   private EntryTeamResponseDTO data;
-
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/EntryTeamResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/EntryTeamResponseDTO.java
@@ -24,12 +24,12 @@ public class EntryTeamResponseDTO {
 
   public static EntryTeamResponseDTO from(EntryTeam entryTeam) {
     return EntryTeamResponseDTO.builder()
-            .id(entryTeam.getId())
-            .name(entryTeam.getName())
-            .phoneNumber(entryTeam.getPhoneNumber())
-            .score(entryTeam.getScore())
-            .user(UserResponseDTO.from(entryTeam.getUser(), null))
-            .club(ClubResponseDTO.from(entryTeam.getClub()))
-            .build();
+        .id(entryTeam.getId())
+        .name(entryTeam.getName())
+        .phoneNumber(entryTeam.getPhoneNumber())
+        .score(entryTeam.getScore())
+        .user(UserResponseDTO.from(entryTeam.getUser(), null))
+        .club(ClubResponseDTO.from(entryTeam.getClub()))
+        .build();
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/EntryTeamsResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/dto/EntryTeamsResponseDTO.java
@@ -1,9 +1,8 @@
 package com.sporthustle.hustle.competitions.entryteam.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/entity/EntryTeam.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/entity/EntryTeam.java
@@ -42,7 +42,8 @@ public class EntryTeam extends BaseEntity {
   private User user;
 
   @Builder
-  private EntryTeam(String name, String phoneNumber, Competition competition, Club club, User user) {
+  private EntryTeam(
+      String name, String phoneNumber, Competition competition, Club club, User user) {
     this.name = name;
     this.phoneNumber = phoneNumber;
     this.competition = competition;

--- a/src/main/java/com/sporthustle/hustle/competitions/entryteam/repository/EntryTeamRepository.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/entryteam/repository/EntryTeamRepository.java
@@ -1,10 +1,9 @@
 package com.sporthustle.hustle.competitions.entryteam.repository;
 
 import com.sporthustle.hustle.competitions.entryteam.entity.EntryTeam;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EntryTeamRepository extends JpaRepository<EntryTeam, Long> {
   List<EntryTeam> findAllByCompetition_Id(Long competitonId);

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailController.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailController.java
@@ -1,5 +1,10 @@
 package com.sporthustle.hustle.competitions.ingame;
 
+import com.sporthustle.hustle.common.annotation.UserId;
+import com.sporthustle.hustle.competitions.ingame.dto.DetailResponseDTO;
+import com.sporthustle.hustle.competitions.ingame.dto.InGameType;
+import com.sporthustle.hustle.competitions.ingame.dto.UpdateDetailRequestDTO;
+import com.sporthustle.hustle.competitions.ingame.dto.UpdateDetailResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -16,23 +21,31 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CompetitionDetailController {
 
+  private final CompetitionDetailService competitionDetailService;
+
   @Operation(summary = "대회 세부 정보 조회 API")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "대회 참가팀 조회에 성공한 경우"),
   })
   @GetMapping("/{competition_id}/{type}/detail")
-  public ResponseEntity<Object> getDetail(
-      @PathVariable("competition_id") Long competitionId, @PathVariable("type") String type) {
-    return ResponseEntity.ok(null);
+  public ResponseEntity<DetailResponseDTO> getDetail(
+      @PathVariable("competition_id") Long competitionId, @PathVariable("type") InGameType type) {
+    DetailResponseDTO detailResponseDTO = competitionDetailService.getDetail(competitionId, type);
+    return ResponseEntity.ok(detailResponseDTO);
   }
 
   @Operation(summary = "대회 세부 정보 업데이트 (개설자) API")
   @ApiResponses({
-    @ApiResponse(responseCode = "200", description = "대회 참가팀 조회에 성공한 경우"),
+    @ApiResponse(responseCode = "200", description = "대회 참가팀 수정에 성공한 경우"),
   })
   @PutMapping("/{competition_id}/{type}/detail")
-  public ResponseEntity<Object> updateDetail(
-      @PathVariable("competition_id") Long competitionId, @PathVariable("type") String type) {
-    return ResponseEntity.ok(null);
+  public ResponseEntity<UpdateDetailResponseDTO> updateDetail(
+      @UserId Long userId,
+      @PathVariable("competition_id") Long competitionId,
+      @PathVariable("type") InGameType type,
+      @RequestBody UpdateDetailRequestDTO updateDetailRequestDTO) {
+    UpdateDetailResponseDTO updateDetailResponseDTO =
+        competitionDetailService.updateDetail(userId, competitionId, type, updateDetailRequestDTO);
+    return ResponseEntity.ok(updateDetailResponseDTO);
   }
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailService.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailService.java
@@ -1,0 +1,156 @@
+package com.sporthustle.hustle.competitions.ingame;
+
+import com.sporthustle.hustle.common.exception.BaseException;
+import com.sporthustle.hustle.common.exception.ErrorCode;
+import com.sporthustle.hustle.competitions.competition.CompetitionUtils;
+import com.sporthustle.hustle.competitions.competition.entity.Competition;
+import com.sporthustle.hustle.competitions.competition.repository.CompetitionRepository;
+import com.sporthustle.hustle.competitions.ingame.dto.DetailResponseDTO;
+import com.sporthustle.hustle.competitions.ingame.dto.InGameType;
+import com.sporthustle.hustle.competitions.ingame.dto.UpdateDetailRequestDTO;
+import com.sporthustle.hustle.competitions.ingame.dto.UpdateDetailResponseDTO;
+import com.sporthustle.hustle.competitions.ingame.entity.FinalRoundDetail;
+import com.sporthustle.hustle.competitions.ingame.entity.PreRoundDetail;
+import com.sporthustle.hustle.competitions.ingame.repository.FinalRoundDetailRepository;
+import com.sporthustle.hustle.competitions.ingame.repository.PreRoundDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CompetitionDetailService {
+
+  private final PreRoundDetailRepository preRoundDetailRepository;
+  private final FinalRoundDetailRepository finalRoundDetailRepository;
+  private final CompetitionRepository competitionRepository;
+
+  @Transactional
+  public void createDetails(Long competitionId) {
+    Competition competition =
+        CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
+
+    createPreRoundDetail(competition);
+    createFinalRoundDetail(competition);
+  }
+
+  private void createPreRoundDetail(Competition competition) {
+    PreRoundDetail preRoundDetail =
+        PreRoundDetail.builder().timeTableUrl(CompetitionDetailUtils.DEFAULT_TIMETABLE_URL).build();
+    preRoundDetail.updateCompetition(competition);
+    preRoundDetailRepository.save(preRoundDetail);
+  }
+
+  private void createFinalRoundDetail(Competition competition) {
+    FinalRoundDetail finalRoundDetail =
+        FinalRoundDetail.builder()
+            .timeTableUrl(CompetitionDetailUtils.DEFAULT_TIMETABLE_URL)
+            .build();
+    finalRoundDetail.updateCompetition(competition);
+    finalRoundDetailRepository.save(finalRoundDetail);
+  }
+
+  @Transactional
+  public void deleteDetails(Long competitionId) {
+    deletePreRoundDetail(competitionId);
+    deleteFinalRoundDetail(competitionId);
+  }
+
+  private void deletePreRoundDetail(Long competitionId) {
+    PreRoundDetail preRoundDetail =
+        preRoundDetailRepository
+            .findByCompetition_Id(competitionId)
+            .orElseThrow(() -> BaseException.from(ErrorCode.PRE_ROUND_DETAIL_NOT_FOUND));
+
+    preRoundDetailRepository.delete(preRoundDetail);
+  }
+
+  private void deleteFinalRoundDetail(Long competitionId) {
+    FinalRoundDetail finalRoundDetail =
+        finalRoundDetailRepository
+            .findByCompetition_Id(competitionId)
+            .orElseThrow(() -> BaseException.from(ErrorCode.PRE_ROUND_DETAIL_NOT_FOUND));
+
+    finalRoundDetailRepository.delete(finalRoundDetail);
+  }
+
+  @Transactional(readOnly = true)
+  public DetailResponseDTO getDetail(Long competitionId, InGameType type) {
+    DetailResponseDTO detailResponseDTO = null;
+
+    switch (type) {
+      case PREROUND:
+        PreRoundDetail preRoundDetail =
+            CompetitionDetailUtils.getPreRoundDetail(competitionId, preRoundDetailRepository);
+        detailResponseDTO = DetailResponseDTO.from(preRoundDetail);
+        break;
+      case FINALROUND:
+        FinalRoundDetail finalRoundDetail =
+            CompetitionDetailUtils.getFinalRoundDetail(competitionId, finalRoundDetailRepository);
+        detailResponseDTO = DetailResponseDTO.from(finalRoundDetail);
+        break;
+      default:
+        throw new IllegalArgumentException("InGameType 해당하는 값이 없습니다.");
+    }
+
+    return detailResponseDTO;
+  }
+
+  @Transactional
+  public UpdateDetailResponseDTO updateDetail(
+      Long userId,
+      Long competitionId,
+      InGameType type,
+      UpdateDetailRequestDTO updateDetailRequestDTO) {
+    UpdateDetailResponseDTO updateDetailResponseDTO = null;
+
+    validateCompetitionOwner(userId, competitionId);
+
+    switch (type) {
+      case PREROUND:
+        updatePreRoundDetail(competitionId, updateDetailRequestDTO);
+        break;
+      case FINALROUND:
+        updateFinalRoundDetail(competitionId, updateDetailRequestDTO);
+        break;
+      default:
+        throw new IllegalArgumentException("InGameType 해당하는 값이 없습니다.");
+    }
+
+    DetailResponseDTO detailResponseDTO =
+        DetailResponseDTO.builder().timeTableUrl(updateDetailRequestDTO.getTimeTableUrl()).build();
+
+    updateDetailResponseDTO =
+        UpdateDetailResponseDTO.builder()
+            .message("대회 세부 정보를 성공적으로 수정했습니다.")
+            .data(detailResponseDTO)
+            .build();
+
+    return updateDetailResponseDTO;
+  }
+
+  private void validateCompetitionOwner(Long userId, Long competitionId) {
+    Competition competition =
+        CompetitionUtils.getCompetitionById(competitionId, competitionRepository);
+
+    if (competition.getUser().getId() != userId) {
+      throw BaseException.from(ErrorCode.USER_NOT_OWNER);
+    }
+  }
+
+  public void updatePreRoundDetail(
+      Long competitionId, UpdateDetailRequestDTO updateDetailRequestDTO) {
+    PreRoundDetail preRoundDetail =
+        CompetitionDetailUtils.getPreRoundDetail(competitionId, preRoundDetailRepository);
+    preRoundDetail.updateTimeTableUrl(updateDetailRequestDTO.getTimeTableUrl());
+    preRoundDetailRepository.save(preRoundDetail);
+  }
+
+  public void updateFinalRoundDetail(
+      Long competitionId, UpdateDetailRequestDTO updateDetailRequestDTO) {
+    FinalRoundDetail finalRoundDetail =
+        CompetitionDetailUtils.getFinalRoundDetail(competitionId, finalRoundDetailRepository);
+    finalRoundDetail.updateTimeTableUrl(updateDetailRequestDTO.getTimeTableUrl());
+    finalRoundDetailRepository.save(finalRoundDetail);
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailUtils.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/CompetitionDetailUtils.java
@@ -1,0 +1,30 @@
+package com.sporthustle.hustle.competitions.ingame;
+
+import com.sporthustle.hustle.common.exception.BaseException;
+import com.sporthustle.hustle.common.exception.ErrorCode;
+import com.sporthustle.hustle.competitions.ingame.entity.FinalRoundDetail;
+import com.sporthustle.hustle.competitions.ingame.entity.PreRoundDetail;
+import com.sporthustle.hustle.competitions.ingame.repository.FinalRoundDetailRepository;
+import com.sporthustle.hustle.competitions.ingame.repository.PreRoundDetailRepository;
+
+public class CompetitionDetailUtils {
+  public static final String DEFAULT_TIMETABLE_URL = "";
+
+  public static PreRoundDetail getPreRoundDetail(
+      Long competitionId, PreRoundDetailRepository preRoundDetailRepository) {
+    PreRoundDetail preRoundDetail =
+        preRoundDetailRepository
+            .findByCompetition_Id(competitionId)
+            .orElseThrow(() -> BaseException.from(ErrorCode.PRE_ROUND_DETAIL_NOT_FOUND));
+    return preRoundDetail;
+  }
+
+  public static FinalRoundDetail getFinalRoundDetail(
+      Long competitionId, FinalRoundDetailRepository finalRoundDetailRepository) {
+    FinalRoundDetail finalRoundDetail =
+        finalRoundDetailRepository
+            .findByCompetition_Id(competitionId)
+            .orElseThrow(() -> BaseException.from(ErrorCode.PRE_ROUND_DETAIL_NOT_FOUND));
+    return finalRoundDetail;
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/DetailResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/DetailResponseDTO.java
@@ -1,0 +1,21 @@
+package com.sporthustle.hustle.competitions.ingame.dto;
+
+import com.sporthustle.hustle.competitions.ingame.entity.FinalRoundDetail;
+import com.sporthustle.hustle.competitions.ingame.entity.PreRoundDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailResponseDTO {
+
+  private String timeTableUrl;
+
+  public static DetailResponseDTO from(PreRoundDetail preRoundDetail) {
+    return DetailResponseDTO.builder().timeTableUrl(preRoundDetail.getTimeTableUrl()).build();
+  }
+
+  public static DetailResponseDTO from(FinalRoundDetail finalRoundDetail) {
+    return DetailResponseDTO.builder().timeTableUrl(finalRoundDetail.getTimeTableUrl()).build();
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/InGameType.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/InGameType.java
@@ -1,0 +1,21 @@
+package com.sporthustle.hustle.competitions.ingame.dto;
+
+public enum InGameType {
+  PREROUND,
+  FINALROUND,
+  ;
+
+  public static InGameType of(String inGameTypeString) {
+    if (inGameTypeString == null) {
+      throw new IllegalArgumentException("inGameTypeString 이 null 입니다.");
+    }
+
+    for (InGameType inGameType : InGameType.values()) {
+      if (inGameType.name().equals(inGameTypeString)) {
+        return inGameType;
+      }
+    }
+
+    return InGameType.PREROUND;
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/UpdateDetailRequestDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/UpdateDetailRequestDTO.java
@@ -1,0 +1,9 @@
+package com.sporthustle.hustle.competitions.ingame.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateDetailRequestDTO {
+
+  private String timeTableUrl;
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/UpdateDetailResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/dto/UpdateDetailResponseDTO.java
@@ -1,0 +1,13 @@
+package com.sporthustle.hustle.competitions.ingame.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateDetailResponseDTO {
+
+  private String message;
+
+  private DetailResponseDTO data;
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/FinalRoundDetail.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/FinalRoundDetail.java
@@ -2,9 +2,9 @@ package com.sporthustle.hustle.competitions.ingame.entity;
 
 import com.sporthustle.hustle.common.entity.BaseEntity;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
-
 import javax.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +24,17 @@ public class FinalRoundDetail extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "competition_id", nullable = false)
   private Competition competition;
+
+  @Builder
+  private FinalRoundDetail(String timeTableUrl) {
+    this.timeTableUrl = timeTableUrl;
+  }
+
+  public void updateCompetition(Competition competition) {
+    this.competition = competition;
+  }
+
+  public void updateTimeTableUrl(String timeTableUrl) {
+    this.timeTableUrl = timeTableUrl;
+  }
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/FinalRoundTeam.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/FinalRoundTeam.java
@@ -3,7 +3,6 @@ package com.sporthustle.hustle.competitions.ingame.entity;
 import com.sporthustle.hustle.common.entity.BaseEntity;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
 import com.sporthustle.hustle.competitions.entryteam.entity.EntryTeam;
-
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/PreRoundDetail.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/PreRoundDetail.java
@@ -2,9 +2,9 @@ package com.sporthustle.hustle.competitions.ingame.entity;
 
 import com.sporthustle.hustle.common.entity.BaseEntity;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
-
 import javax.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +24,17 @@ public class PreRoundDetail extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "competition_id", nullable = false)
   private Competition competition;
+
+  @Builder
+  private PreRoundDetail(String timeTableUrl) {
+    this.timeTableUrl = timeTableUrl;
+  }
+
+  public void updateCompetition(Competition competition) {
+    this.competition = competition;
+  }
+
+  public void updateTimeTableUrl(String timeTableUrl) {
+    this.timeTableUrl = timeTableUrl;
+  }
 }

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/PreRoundGroup.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/entity/PreRoundGroup.java
@@ -3,7 +3,6 @@ package com.sporthustle.hustle.competitions.ingame.entity;
 import com.sporthustle.hustle.common.entity.BaseEntity;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
 import com.sporthustle.hustle.competitions.entryteam.entity.EntryTeam;
-
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/repository/FinalRoundDetailRepository.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/repository/FinalRoundDetailRepository.java
@@ -1,0 +1,9 @@
+package com.sporthustle.hustle.competitions.ingame.repository;
+
+import com.sporthustle.hustle.competitions.ingame.entity.FinalRoundDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FinalRoundDetailRepository extends JpaRepository<FinalRoundDetail, Long> {
+  Optional<FinalRoundDetail> findByCompetition_Id(Long competitionId);
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/ingame/repository/PreRoundDetailRepository.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/ingame/repository/PreRoundDetailRepository.java
@@ -1,0 +1,9 @@
+package com.sporthustle.hustle.competitions.ingame.repository;
+
+import com.sporthustle.hustle.competitions.ingame.entity.PreRoundDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PreRoundDetailRepository extends JpaRepository<PreRoundDetail, Long> {
+  Optional<PreRoundDetail> findByCompetition_Id(Long competitionId);
+}

--- a/src/main/java/com/sporthustle/hustle/competitions/match/entity/MatchResultPost.java
+++ b/src/main/java/com/sporthustle/hustle/competitions/match/entity/MatchResultPost.java
@@ -2,7 +2,6 @@ package com.sporthustle.hustle.competitions.match.entity;
 
 import com.sporthustle.hustle.common.entity.BaseEntity;
 import com.sporthustle.hustle.competitions.competition.entity.Competition;
-
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Feature/#63`

### 💡 작업동기
- 대회 예선 / 본선 타임테이블을 저장하는 세부 정보 도메인 작성

### 🔑 주요 변경사항
- 대회 예선 / 본선 세부 정보 도메인 코드 작성 ( 서비스 / 컨트롤러 / 레포지토리 / DTO )
- 대회 생성 시 예선 / 본선 세부 정보 기본적으로 생성하도록 수정 ( 기본 이미지는 추후 추가 예정 )

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #63 

### 참고 사항
#61 PR 베이스로 작성했습니다. 이 PR 을 머지한 이후에 머지하겠습니다.