### PR TITLE
[Refactor] 파일 업로드 로직 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,5 +85,6 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "com.amazonaws.sdk.disableEc2Metadata", "true"
 	systemProperty "jasypt.encryptor.password", System.getProperty("jasypt.encryptor.password")
 }

--- a/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
+++ b/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
   MATCH_RESULT_POST_NOT_FOUND(BAD_REQUEST, "MATCH_RESULT_POST_NOT_FOUND", "경기 결과를 찾을 수 없습니다."),
   FRIEND_MATCHING_POST_NOT_FOUND(
       BAD_REQUEST, "FRIEND_MATCHING_POST_NOT_FOUND", "해당 교류전글을 찾을 수 없습니다."),
+  FILE_SIZE_LIMIT(PAYLOAD_TOO_LARGE, "FILE_SIZE_LIMIT", "파일 사이즈가 10MB 보다 큽니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
+++ b/src/main/java/com/sporthustle/hustle/common/exception/ErrorCode.java
@@ -1,7 +1,6 @@
 package com.sporthustle.hustle.common.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.*;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -25,6 +24,8 @@ public enum ErrorCode {
   FRIEND_MATCHING_POST_NOT_FOUND(
       BAD_REQUEST, "FRIEND_MATCHING_POST_NOT_FOUND", "해당 교류전글을 찾을 수 없습니다."),
   FILE_SIZE_LIMIT(PAYLOAD_TOO_LARGE, "FILE_SIZE_LIMIT", "파일 사이즈가 10MB 보다 큽니다."),
+  FILE_UPLOAD_FAILED(BAD_REQUEST, "FILE_UPLOAD_FAILED", "파일 업로드에 실패했습니다."),
+  FILE_NOT_IMAGE(BAD_REQUEST, "FILE_NOT_IMAGE", "파일이 이미지 형식이 아닙니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/sporthustle/hustle/common/exception/FileUploadExceptionHandler.java
+++ b/src/main/java/com/sporthustle/hustle/common/exception/FileUploadExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.sporthustle.hustle.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class FileUploadExceptionHandler {
+
+  @ExceptionHandler(SizeLimitExceededException.class)
+  public ResponseEntity<ErrorMessage> handleSizeLimitExceededException(Exception ex) {
+    return ErrorMessage.toResponseEntity(
+        BaseException.from(ErrorCode.FILE_SIZE_LIMIT).getErrorCode());
+  }
+}

--- a/src/main/java/com/sporthustle/hustle/infra/s3/S3Controller.java
+++ b/src/main/java/com/sporthustle/hustle/infra/s3/S3Controller.java
@@ -1,14 +1,15 @@
 package com.sporthustle.hustle.infra.s3;
 
 import com.sporthustle.hustle.infra.s3.dto.S3UploadResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "S3 File Upload", description = "s3 파일 업로드 API")
@@ -20,8 +21,12 @@ public class S3Controller {
 
   private final S3Service s3Service;
 
-  @PostMapping("/upload")
-  public ResponseEntity<S3UploadResponseDTO> uploadFile(@RequestParam("file") MultipartFile file) {
+  @Operation(summary = "파일 업로드 API")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "파일 업로드에 성공한 경우"),
+  })
+  @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<S3UploadResponseDTO> uploadFile(@RequestPart("file") MultipartFile file) {
     S3UploadResponseDTO s3UploadResponseDTO = s3Service.uploadFile(file);
     return ResponseEntity.ok(s3UploadResponseDTO);
   }

--- a/src/main/java/com/sporthustle/hustle/infra/s3/S3Service.java
+++ b/src/main/java/com/sporthustle/hustle/infra/s3/S3Service.java
@@ -6,6 +6,8 @@ import com.sporthustle.hustle.common.exception.BaseException;
 import com.sporthustle.hustle.common.exception.ErrorCode;
 import com.sporthustle.hustle.infra.s3.dto.S3UploadResponseDTO;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,18 +22,41 @@ public class S3Service {
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
 
+  @Value("${cloud.aws.s3.bucket_url}")
+  private String bucketUrl;
+
   public S3UploadResponseDTO uploadFile(MultipartFile file) {
-    try {
-      String fileName = file.getOriginalFilename();
-      String fileUrl = "https://" + bucket + "/test" + fileName;
-      ObjectMetadata metadata = new ObjectMetadata();
-      metadata.setContentType(file.getContentType());
-      metadata.setContentLength(file.getSize());
-      amazonS3Client.putObject(bucket, fileName, file.getInputStream(), metadata);
-      return S3UploadResponseDTO.builder().message("업로드 완료되었습니다.").build();
+    String generatedFileName = buildFileName(file.getOriginalFilename());
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType(file.getContentType());
+    metadata.setContentLength(file.getSize());
+
+    validateImageFile(file);
+
+    try (InputStream inputStream = file.getInputStream()) {
+      amazonS3Client.putObject(bucket, generatedFileName, inputStream, metadata);
     } catch (IOException e) {
-      e.printStackTrace();
-      throw BaseException.from(ErrorCode.USER_NOT_FOUND);
+      throw BaseException.from(ErrorCode.FILE_UPLOAD_FAILED);
+    }
+
+    String fileUrl = bucketUrl + "/" + generatedFileName;
+    return S3UploadResponseDTO.builder().message("업로드 완료되었습니다.").data(fileUrl).build();
+  }
+
+  private String buildFileName(String originalFileName) {
+    if (originalFileName.indexOf('.') == -1) {
+      throw new IllegalArgumentException("파일 확장자가 존재하지 않는 파일입니다.");
+    }
+
+    String[] fileSplitByDot = originalFileName.split("\\.");
+    String fileExtension = fileSplitByDot[fileSplitByDot.length - 1];
+    return UUID.randomUUID() + "." + fileExtension;
+  }
+
+  private void validateImageFile(MultipartFile file) {
+    if (!file.getContentType().startsWith("image")) {
+      throw BaseException.from(ErrorCode.FILE_NOT_IMAGE);
     }
   }
 }

--- a/src/main/java/com/sporthustle/hustle/infra/s3/dto/S3UploadResponseDTO.java
+++ b/src/main/java/com/sporthustle/hustle/infra/s3/dto/S3UploadResponseDTO.java
@@ -8,4 +8,6 @@ import lombok.Getter;
 public class S3UploadResponseDTO {
 
   private String message;
+
+  private String data;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,11 +51,14 @@ cloud:
   aws:
     s3:
       bucket: ENC(NUG0m3ZU5uTDSjVaNWQvzeQk7kddxsAu7ghVY3SSOeU=)
-    stack.auto: false
-    region.static: ap-northeast-2
+      bucket_url: ENC(h+QPpUStzZUzo2LTKi3L+97pfV+dxJymaYVTkoc14zATlXL6uXs9ldEfGEAfL6mB)
+    stack:
+      auto: false
+    region:
+      static: ap-northeast-2
     credentials:
-      accessKey: ENC(bYb2yz7qpUVLVhKadqPTuOVpZ+kz/UkEKfybZe2Dolg=)
-      secretKey: ENC(vnorb8IpdHSd+WMtG4T3Az6CPn2hiZUgXFljBRIDxocdZthTq+cX499pML8C6yiTsfT5KVcozDI=)
+      accessKey: ENC(HXnZDXuPkt4xvKR4fdDGbZrfio+yGJ4xDLLlsPS4m3k=)
+      secretKey: ENC(NjUhcg12GDuIiVp7Ho7hWvE4fmGF/n/dim6kRNdYvreNw+Ibx2mk+PkvVsWQynLGiIPwNWlY+OQ=)
 ---
 spring.config:
   activate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 ### jpa setting ###
 spring:
+  servlet:
+    multipart:
+      maxFileSize: 10MB
+      maxRequestSize: 10MB
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Refactor/#92`

### 💡 작업동기
- 스웨거에서 파일 업로드가 불가능하고 URL 을 넘겨주지 않는 이슈가 있어 수정
- 그 외 업로드 로직 리팩터링

### 🔑 주요 변경사항
- 스웨거에서 파일 업로드 불가능한 이슈 수정
- 원본 파일 이름 노출하지말고 랜덤으로 생성
- 다운로드 받을 수 있는 URL 출력
  - CloudFront 연동한 도메인으로 합치도록 `application.yml` 에 URL 설정 추가 ( `https://storage.sport-hustle.com` )
- 예외 처리 변경
  - 파일 업로드 실패 시 `USER_NOT_FOUND` 으로 예상치 못한 예외 발생 시키는 로직 `FILE_UPLOAD_FAILED` 예외 처리하도록 수정
  - 파일 사이즈 초과 시 Spring MVC 단에서 발생하는 예외 캡쳐해 허슬 커스텀 예외로 발생하도록 추가 
  - 이미지 파일 확장자만 업로드할 수 있도록 예외 처리

### 🏞 스크린샷
스웨거에서 아래처럼 파일 입력 버튼이 생깁니다.
<img width="558" alt="스크린샷 2023-08-22 오후 4 16 49" src="https://github.com/HUSTLE-UMC/HUSTLE_server/assets/16275188/8a5559ac-25d1-4d35-9e73-59123cd4c8c3">

아래처럼 CloudFront 도메인이 연동된, 업로드 파일 URL 이 출력하도록 추가
<img width="695" alt="스크린샷 2023-08-22 오후 4 17 21" src="https://github.com/HUSTLE-UMC/HUSTLE_server/assets/16275188/f9ebe6fb-406a-4f24-aaac-b342b358cc0f">

### 참고사항
* 파일 업로드는 프로필 사진, 동아리 사진, 대회 포스터 사진 정도로만 생각했습니다.
* 대회 포스터가 어느정도 사이즈일지 몰라서 10MB 으로 설정했습니다.

### 관련 이슈
- #92 
