### PR TITLE
[Chore/#108] 배포 시 프로필을 분리하여 무중단 배포를 진행합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.15.Final'
 	implementation group: 'org.n52.jackson', name: 'jackson-datatype-jts', version: '1.2.7'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,8 +18,55 @@ START_LOG="$HOME_ROOT/logs/start.log"
 
 NOW=$(date +%c)
 
+echo "> 현재 구동중인 profile 확인"
+CURRENT_PROFILE=$(curl -s http://localhost/profile)
+echo "> $CURRENT_PROFILE"
+if [ $CURRENT_PROFILE == prod1 ]
+then
+	IDLE_PROFILE=prod2
+	IDLE_PORT=8081
+elif [ $CURRENT_PROFILE == prod2 ]
+then
+	IDLE_PROFILE=prod1
+	IDLE_PORT=8080
+else
+	echo "> 일치하는 Profile이 없습니다. Profile: $CURRENT_PROFILE"
+	echo "> prod1을 할당합니다. IDLE_PROFILE: prod1"
+	IDLE_PROFILE=prod1
+	IDLE_PORT=8080
+fi
+
+
 echo "[$NOW] > $JAR 실행" >> $START_LOG
-nohup java -jar $JAR --jasypt.encryptor.password=$JASYPT_PASSWORD --spring.profiles.active=prod > $APP_LOG 2> $ERROR_LOG &
+nohup java -jar $JAR --jasypt.encryptor.password=$JASYPT_PASSWORD --spring.profiles.active=$IDLE_PROFILE > $APP_LOG 2> $ERROR_LOG &
 
 SERVICE_PID=$(pgrep -f $JAR)
 echo "[$NOW] > 서비스 PID: $SERVICE_PID" >> $START_LOG
+
+echo "> $IDLE_PROFILE 10초 후 Health check 시작"
+echo "> curl -s http://localhost:$IDLE_PORT/actuator/health "
+sleep 10
+for retry_count in {1..10}
+do
+	response=$(curl -s http://localhost:$IDLE_PORT/actuator/health)
+	up_count=$(echo $response | grep 'UP' | wc -l)
+	if [ $up_count -ge 1 ]
+	then
+		echo "> Health check 성공"
+		break
+	else
+		echo "> Health check의 응답을 알 수 없거나 혹은 status가 UP이 아닙니다."
+		echo "> Health check: ${response}"
+	fi
+	if [ $retry_count -eq 10 ]
+	then
+		echo "> Health check 실패. "
+		echo "> Nginx에 연결하지 않고 배포를 종료합니다."
+		exit 1
+	fi
+	echo "> Health check 연결 실패. 재시도..."
+	sleep 10
+done
+echo "> 스위칭을 시도합니다..."
+sleep 10
+sh /home/ubuntu/deploy/scripts/switch.sh

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+echo "> 현재 구동중인 Port 확인"
+CURRENT_PROFILE=$(curl -s http://localhost/profile)
+
+if [ $CURRENT_PROFILE == prod1 ]
+then
+	IDLE_PORT=8081
+elif [ $CURRENT_PROFILE == prod2 ]
+then
+	IDLE_PORT=8080
+else
+	echo "> 일치하는 Profile이 없습니다. Profile:$CURRENT_PROFILE"
+	echo "> 8080를 할당합니다."
+	IDLE_PORT=8080
+fi
+
+PROXY_PORT=$(curl -s http://localhost/profile)
+echo "> 현재 구동중인 Port: $PROXY_PORT"
+
+echo "> 전환할 Port : $IDLE_PORT"
+echo "> Port 전환"
+echo "set \$service_url http://127.0.0.1:${IDLE_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
+
+echo "> Nginx Reload"
+sudo service nginx reload

--- a/src/main/java/com/sporthustle/hustle/HealthController.java
+++ b/src/main/java/com/sporthustle/hustle/HealthController.java
@@ -2,19 +2,31 @@ package com.sporthustle.hustle;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
+
 @Tag(name = "Health", description = "헬스 체크 API")
+@RequiredArgsConstructor
 @RequestMapping
 @RestController
 public class HealthController {
+
+  private final Environment env;
 
   @Operation(summary = "헬스 체크 API", description = "헬스 체크 API 입니다.")
   @GetMapping
   public ResponseEntity<String> health() {
     return ResponseEntity.ok(null);
+  }
+
+  @GetMapping("/profile")
+  public String getProfile() {
+    return Arrays.stream(env.getActiveProfiles()).findFirst().orElse("");
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ cloud:
 ---
 spring.config:
   activate:
-    on-profile: prod
+    on-profile: prod1
 
 spring:
   jpa:
@@ -79,3 +79,26 @@ oauth:
   kakao:
     secret:
       redirect-url: ENC(2j1v5MMXa/AqK/Ry8jVuctw/+/27pwQFPrC11SeYZkzidsAhxwEHDeKWni7eGvt8baKOA7tRR+2vV7BOIHs+pg==)
+server:
+  port: 8080
+---
+spring.config:
+  activate:
+    on-profile: prod2
+
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+  datasource:
+    driver-class-name: ENC(4zv7k66bl0S9CkPIg0RRzaWiUGE2DhjRaIxsA8E9l+kWvMMPExbdHg==)
+    url: ENC(n4BgVC45DNHZ7Dv+eIGHp6NmDrt9UVXY93jMqfOq+Eb4lRi9oP6by9eJ3NuZGKrnk1QUdrQ4J2QFWMTvqV9AuCG2y500vtLwPJngcLnbAz1JxooZAJoNCxYOyW1HwFnOY0zEqGA45hhAZxCpZEKn4IPiX8JOxYZpl13BDw/qoExcYplGW3GJVD3mhD1Yqy2B)
+    username: ENC(3IlDHh9Hevic4hySvkJUVfhwVklsc20q)
+    password: ENC(Z9yNmaE1Sk5DKZerehtnl+GNz3MfhVBsrT8obGfbaLU=)
+
+oauth:
+  kakao:
+    secret:
+      redirect-url: ENC(2j1v5MMXa/AqK/Ry8jVuctw/+/27pwQFPrC11SeYZkzidsAhxwEHDeKWni7eGvt8baKOA7tRR+2vV7BOIHs+pg==)
+server:
+  port: 8081


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `Chore/#108`

### 💡 작업동기
- 배포 시 서버 시작까지 다운타임이 10초 가량 있습니다. 이를 방지하기 위해 프로필을 분리하여 포트 두 개로 번갈아가며 배포합니다.

### 🔑 주요 변경사항
- 프로필 분리 : `prod` -> `prod1` (8080 포트) & `prod2` (8081 포트)
- 시작 스크립트 변경 : 남은 프로필로 배포하도록 수정
- 스위칭 스크립트 추가 : nginx 리버스 프록싱하는 서버 포트 수정

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- #108 
